### PR TITLE
Add test command documentation

### DIFF
--- a/docs/cli/api/commands.md
+++ b/docs/cli/api/commands.md
@@ -4,6 +4,7 @@
 
 - [`init`](/cli/api/commands/init) Creates configuration file.
 - [`generate`](/cli/api/commands/generate) Generates code based on configuration, using `contracts` and `plugins`.
+- [`test`](/cli/api/commands/test) Runs tests based on configuration.
 
 ## Display Info
 
@@ -51,3 +52,52 @@ bun wagmi --version
 ```
 :::
 
+## Test Command
+
+The `test` command runs tests based on the configuration provided.
+
+### Usage
+
+```bash
+wagmi test
+```
+
+### Options
+
+#### -c, --config <path>
+
+`string`
+
+Path to config file.
+
+```bash
+wagmi test --config wagmi.config.ts
+```
+
+#### -r, --root <path>
+
+`string`
+
+Root path to resolve config from.
+
+```bash
+wagmi test --root path/to/root
+```
+
+#### -w, --watch
+
+`boolean`
+
+Watch for changes and re-run tests.
+
+```bash
+wagmi test --watch
+```
+
+#### -h, --help
+
+Displays help message.
+
+```bash
+wagmi test --help
+```

--- a/docs/cli/api/commands/test.md
+++ b/docs/cli/api/commands/test.md
@@ -1,0 +1,49 @@
+# test
+
+Runs tests based on the configuration provided.
+
+## Usage
+
+```bash
+wagmi test
+```
+
+## Options
+
+### -c, --config <path>
+
+`string`
+
+Path to config file.
+
+```bash
+wagmi test --config wagmi.config.ts
+```
+
+### -r, --root <path>
+
+`string`
+
+Root path to resolve config from.
+
+```bash
+wagmi test --root path/to/root
+```
+
+### -w, --watch
+
+`boolean`
+
+Watch for changes and re-run tests.
+
+```bash
+wagmi test --watch
+```
+
+### -h, --help
+
+Displays help message.
+
+```bash
+wagmi test --help
+```


### PR DESCRIPTION
Add documentation for the `test` command in the CLI API.

* **docs/cli/api/commands.md**
  - Add a new section for the `test` command.
  - Provide a brief description of the `test` command.
  - Include usage examples and options for the `test` command.

* **docs/cli/api/commands/test.md**
  - Create a new file for the `test` command documentation.
  - Add a title and description for the `test` command.
  - Include usage examples and options for the `test` command.

